### PR TITLE
Implement size and order on base graph type

### DIFF
--- a/src/Gliph/Graph/AdjacencyList.php
+++ b/src/Gliph/Graph/AdjacencyList.php
@@ -26,6 +26,15 @@ abstract class AdjacencyList implements MutableGraph {
 
     protected $vertices;
 
+    /**
+     * Count of the number of edges in the graph.
+     *
+     * We keep track because calculating it on demand is expensive.
+     *
+     * @var int
+     */
+    protected $size = 0;
+
     public function __construct() {
         $this->vertices = new \SplObjectStorage();
     }
@@ -74,5 +83,19 @@ abstract class AdjacencyList implements MutableGraph {
      */
     public function hasVertex($vertex) {
         return $this->vertices->contains($vertex);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function order() {
+        return $this->vertices->count();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function size() {
+        return $this->size;
     }
 }

--- a/src/Gliph/Graph/DirectedAdjacencyList.php
+++ b/src/Gliph/Graph/DirectedAdjacencyList.php
@@ -22,6 +22,10 @@ class DirectedAdjacencyList extends AdjacencyList implements MutableDirectedGrap
             $this->addVertex($head);
         }
 
+        if (!$this->vertices[$tail]->contains($head)) {
+            $this->size++;
+        }
+
         $this->vertices[$tail]->attach($head);
     }
 

--- a/src/Gliph/Graph/Graph.php
+++ b/src/Gliph/Graph/Graph.php
@@ -107,4 +107,18 @@ interface Graph {
      *
      */
     public function outDegree($vertex);
+
+    /**
+     * Returns the number of edges in the graph.
+     *
+     * @return int
+     */
+    public function size();
+
+    /**
+     * Returns the number of vertices in the graph.
+     *
+     * @return int
+     */
+    public function order();
 }

--- a/src/Gliph/Graph/UndirectedAdjacencyList.php
+++ b/src/Gliph/Graph/UndirectedAdjacencyList.php
@@ -18,6 +18,10 @@ class UndirectedAdjacencyList extends AdjacencyList implements MutableUndirected
             $this->addVertex($to);
         }
 
+        if (!$this->vertices[$from]->contains($to)) {
+            $this->size++;
+        }
+
         $this->vertices[$from]->attach($to);
         $this->vertices[$to]->attach($from);
     }

--- a/tests/Gliph/Graph/AdjacencyListTest.php
+++ b/tests/Gliph/Graph/AdjacencyListTest.php
@@ -104,4 +104,15 @@ class AdjacencyListTest extends AdjacencyListBase {
             $this->fail();
         }
     }
+
+    /**
+     * @depends testAddVertex
+     * @covers ::order
+     */
+    public function testOrder() {
+        extract($this->v);
+        $this->g->addVertex($a);
+
+        $this->assertEquals(1, $this->g->order());
+    }
 }

--- a/tests/Gliph/Graph/DirectedAdjacencyListTest.php
+++ b/tests/Gliph/Graph/DirectedAdjacencyListTest.php
@@ -209,4 +209,15 @@ class DirectedAdjacencyListTest extends AdjacencyListBase {
         $this->setExpectedException('\\Gliph\\Exception\\NonexistentVertexException');
         $this->g->outDegree(new \stdClass());
     }
+
+    /**
+     * @depends testAddDirectedEdge
+     * @covers ::size
+     */
+    public function testSize() {
+        list($a, $b) = array_values($this->v);
+        $this->g->addDirectedEdge($a, $b);
+
+        $this->assertEquals(1, $this->g->size());
+    }
 }

--- a/tests/Gliph/Graph/UndirectedAdjacencyListTest.php
+++ b/tests/Gliph/Graph/UndirectedAdjacencyListTest.php
@@ -143,4 +143,15 @@ class UndirectedAdjacencyListTest extends AdjacencyListBase {
         $this->setExpectedException('\\Gliph\\Exception\\NonexistentVertexException');
         $this->g->outDegree(new \stdClass());
     }
+
+    /**
+     * @depends testAddEdge
+     * @covers ::size
+     */
+    public function testSize() {
+        list($a, $b) = array_values($this->v);
+        $this->g->addEdge($a, $b);
+
+        $this->assertEquals(1, $this->g->size());
+    }
 }


### PR DESCRIPTION
Size gives the number of edges in a graph.
Order gives the number of vertices.
Both are very useful information, and deserve to be on the base Graph interface.
